### PR TITLE
Add afterGridGenerated engine hook

### DIFF
--- a/lib/mnswpr.js
+++ b/lib/mnswpr.js
@@ -22,7 +22,8 @@ const PC_BUSY_DELAY = 500
  * @param {String} version
  * @param {{
  * levelChanged: (setting: any) => void,
- * gameDone: (game: any) => void
+ * gameDone: (game: any) => void,
+ * afterGridGenerated?: (setting: any) => void
  * } | undefined } hooks
  */
 const Minesweeper = function(appId, version, hooks = undefined) {
@@ -34,7 +35,8 @@ const Minesweeper = function(appId, version, hooks = undefined) {
   if (!hooks) {
     hooks = {
       levelChanged: () => {},
-      gameDone: () => {}
+      gameDone: () => {},
+      afterGridGenerated: () => {}
     }
   }
 
@@ -224,10 +226,6 @@ const Minesweeper = function(appId, version, hooks = undefined) {
       appElement.style.margin = '0 auto'
     }
 
-    /**
-     * TODO: add hook afterGridGenerated
-     *   - for initializing the leaderboard
-     */
     if (options.initial)
       hooks.levelChanged(setting)
 
@@ -235,6 +233,9 @@ const Minesweeper = function(appId, version, hooks = undefined) {
     updateFlagsCountDisplay()
     addMines(setting.mines)
 
+    // Grid is fully built (cells + mines placed); let consumers react, e.g.
+    // the website uses this to initialize the leaderboard for the level.
+    if (hooks.afterGridGenerated) hooks.afterGridGenerated(setting)
   }
 
   function setBusy() {

--- a/test/minesweeper.test.js
+++ b/test/minesweeper.test.js
@@ -127,6 +127,19 @@ describe('Minesweeper board', () => {
     expect(highlighted).toBe(1)
   })
 
+  it('fires afterGridGenerated with the setting once the board is built', () => {
+    const settings = []
+    const setting = { rows: 4, cols: 5, mines: 3, id: 'test', name: 'test' }
+    mountCustomGame(setting, {
+      levelChanged: () => {},
+      gameDone: () => {},
+      afterGridGenerated: (s) => settings.push(s)
+    })
+
+    expect(settings.length).toBe(1)
+    expect(settings[0]).toMatchObject({ rows: 4, cols: 5, mines: 3, id: 'test' })
+  })
+
   it('declares a win once every safe cell is revealed', () => {
     // A mine-free 3x3 board: one click cascades to reveal all 9 safe cells.
     let finished = null


### PR DESCRIPTION
Implements the long-standing `TODO: add hook afterGridGenerated` in the engine's `generateGrid()`, so consumers can react once the board is fully built without the engine reaching into the app.

- `lib/mnswpr.js` — add `afterGridGenerated` to the hooks JSDoc type and a no-op default; fire it at the end of `generateGrid()`, after both cells and mines are placed. Guarded so callers passing a partial hooks object don't break.
- `test/minesweeper.test.js` — assert the hook fires exactly once with the level's setting on mount.

`app/main.js` is intentionally left unwired: the hook fires on every reset and the app already initializes the leaderboard via `levelChanged`, so opting in would cause redundant Firestore fetches.

Tests and lint pass.
